### PR TITLE
chore: fixing import

### DIFF
--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -1,6 +1,7 @@
 import arg from 'arg';
 import { Params } from '../types';
-import { message, spec } from './';
+import { message } from './utils';
+import { spec } from './spec';
 
 const cli = arg(spec);
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,5 @@
 import calver from 'calver';
-import { usage } from '.';
+import { usage } from './usage';
 import type { Params } from '../types';
 
 const message = (msg?: string): never => {


### PR DESCRIPTION
Avoiding future circular-dependencies errors by not importing from index package.